### PR TITLE
Change partial to not include class prefix

### DIFF
--- a/addon/pods/components/svg-icon/component.js
+++ b/addon/pods/components/svg-icon/component.js
@@ -34,6 +34,6 @@ export default Component.extend({
     return `${this.get('classPrefix')}-${this.get('icon')}`
   }),
   partialPath: computed('computedClassName', function() {
-    return `partials/-${this.get('computedClassName')}`
+    return `partials/-${this.get('icon')}`
   })
 })

--- a/addon/pods/components/svg-icon/component.js
+++ b/addon/pods/components/svg-icon/component.js
@@ -33,7 +33,7 @@ export default Component.extend({
   computedClassName: computed('classPrefix', 'icon', function() {
     return `${this.get('classPrefix')}-${this.get('icon')}`
   }),
-  partialPath: computed('computedClassName', function() {
+  partialPath: computed('icon', function() {
     return `partials/-${this.get('icon')}`
   })
 })


### PR DESCRIPTION
Currently, if you set any prefix for the class, it will not be able to find the partial to display the icon.  This makes a change so that the css can be adjusted without breaking the icon.

No QA needed.
